### PR TITLE
Add predict method for reconstruction

### DIFF
--- a/src/pythae/models/base/base_model.py
+++ b/src/pythae/models/base/base_model.py
@@ -89,7 +89,6 @@ class BaseAE(nn.Module):
 
         self.device = None
 
-
     def forward(self, inputs: BaseDataset, **kwargs) -> ModelOutput:
         """Main forward pass outputing the VAE outputs
         This function should output a :class:`~pythae.models.base.base_utils.ModelOutput` instance
@@ -139,7 +138,6 @@ class BaseAE(nn.Module):
         )
 
         return output
-
 
     def interpolate(
         self,

--- a/src/pythae/models/base/base_model.py
+++ b/src/pythae/models/base/base_model.py
@@ -89,6 +89,7 @@ class BaseAE(nn.Module):
 
         self.device = None
 
+
     def forward(self, inputs: BaseDataset, **kwargs) -> ModelOutput:
         """Main forward pass outputing the VAE outputs
         This function should output a :class:`~pythae.models.base.base_utils.ModelOutput` instance
@@ -116,6 +117,29 @@ class BaseAE(nn.Module):
             torch.Tensor: A tensor of shape [B x input_dim] containing the reconstructed samples.
         """
         return self(DatasetOutput(data=inputs)).recon_x
+
+    def predict(self, inputs: BaseDataset, **kwargs) -> ModelOutput:
+        """The input data is encoded and decoded without computing loss
+
+        Args:
+            inputs (BaseDataset): An instance of pythae's datasets
+
+        Returns:
+            ModelOutput: An instance of ModelOutput containing reconstruction and embedding
+        """
+
+        x = inputs["data"]
+
+        z = self.encoder(x).embedding
+        recon_x = self.decoder(z)["reconstruction"]
+
+        output = ModelOutput(
+            recon_x=recon_x,
+            embedding=z,
+        )
+
+        return output
+
 
     def interpolate(
         self,

--- a/src/pythae/models/beta_tc_vae/beta_tc_vae_model.py
+++ b/src/pythae/models/beta_tc_vae/beta_tc_vae_model.py
@@ -79,7 +79,7 @@ class BetaTCVAE(VAE):
         )
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/beta_vae/beta_vae_model.py
+++ b/src/pythae/models/beta_vae/beta_vae_model.py
@@ -71,7 +71,7 @@ class BetaVAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/ciwae/ciwae_model.py
+++ b/src/pythae/models/ciwae/ciwae_model.py
@@ -78,7 +78,7 @@ class CIWAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x.reshape(x.shape[0], self.n_samples, -1)[:, 0, :].reshape_as(

--- a/src/pythae/models/disentangled_beta_vae/disentangled_beta_vae_model.py
+++ b/src/pythae/models/disentangled_beta_vae/disentangled_beta_vae_model.py
@@ -79,7 +79,7 @@ class DisentangledBetaVAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z, epoch)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/info_vae/info_vae_model.py
+++ b/src/pythae/models/info_vae/info_vae_model.py
@@ -77,7 +77,7 @@ class INFOVAE_MMD(VAE):
 
         output = ModelOutput(
             loss=loss,
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld_loss,
             mmd_loss=mmd_loss,
             recon_x=recon_x,

--- a/src/pythae/models/iwae/iwae_model.py
+++ b/src/pythae/models/iwae/iwae_model.py
@@ -77,7 +77,7 @@ class IWAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x.reshape(x.shape[0], self.n_samples, -1)[:, 0, :].reshape_as(

--- a/src/pythae/models/miwae/miwae_model.py
+++ b/src/pythae/models/miwae/miwae_model.py
@@ -86,7 +86,7 @@ class MIWAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x.reshape(

--- a/src/pythae/models/msssim_vae/msssim_vae_model.py
+++ b/src/pythae/models/msssim_vae/msssim_vae_model.py
@@ -72,7 +72,7 @@ class MSSSIM_VAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/piwae/piwae_model.py
+++ b/src/pythae/models/piwae/piwae_model.py
@@ -90,7 +90,7 @@ class PIWAE(VAE):
         loss = miwae_loss + iwae_loss
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             encoder_loss=miwae_loss,

--- a/src/pythae/models/pvae/pvae_model.py
+++ b/src/pythae/models/pvae/pvae_model.py
@@ -115,7 +115,7 @@ class PoincareVAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, z, qz_x)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/svae/svae_model.py
+++ b/src/pythae/models/svae/svae_model.py
@@ -88,7 +88,7 @@ class SVAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, loc, concentration, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vae/vae_model.py
+++ b/src/pythae/models/vae/vae_model.py
@@ -88,7 +88,7 @@ class VAE(BaseAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vae_iaf/vae_iaf_model.py
+++ b/src/pythae/models/vae_iaf/vae_iaf_model.py
@@ -93,7 +93,7 @@ class VAE_IAF(VAE):
         )
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vae_lin_nf/vae_lin_nf_model.py
+++ b/src/pythae/models/vae_lin_nf/vae_lin_nf_model.py
@@ -106,7 +106,7 @@ class VAE_LinNF(VAE):
         )
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vamp/vamp_model.py
+++ b/src/pythae/models/vamp/vamp_model.py
@@ -91,7 +91,7 @@ class VAMP(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z, epoch)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,


### PR DESCRIPTION
Hello @clementchadebec ,

As discussed on Thursday, here is a small PR with two contribution:
* homogenizing the forward method outputs for all the models, the key for the reconstruction loss is `recon_loss`. If you think `reconstruction_loss` is better I can change it for the second option.
* Adding a `predict` method to the BaseAE class in order to compute the model outputs (reconstruction and embedding) without having to compute the loss or posterior parameters (embedding is equal to z in inference mode if I understand well). This might be overlapping with the `reconstruct`, let me know what di you think of it, it might not be useful to add to the main code.

Have a good week, 
Ravi