### PR TITLE
Return the random indices selected to reconstruct "recon_x"

### DIFF
--- a/src/pythae/models/factor_vae/factor_vae_model.py
+++ b/src/pythae/models/factor_vae/factor_vae_model.py
@@ -124,8 +124,9 @@ class FactorVAE(VAE):
             autoencoder_loss=autoencoder_loss,
             discriminator_loss=discriminator_loss,
             recon_x=recon_x,
+            recon_x_indices=idx_1,
             z=z,
-            z_bis_permuted=z_bis_permuted,
+            z_bis_permuted=z_bis_permuted
         )
 
         return output

--- a/tests/test_FactorVAE.py
+++ b/tests/test_FactorVAE.py
@@ -306,6 +306,7 @@ class Test_Model_forward:
                     "autoencoder_loss",
                     "discriminator_loss",
                     "recon_x",
+                    "recon_x_indices",
                     "z",
                     "z_bis_permuted",
                 ]
@@ -321,6 +322,7 @@ class Test_Model_forward:
             int(demo_data["data"].shape[0] / 2)
             + 1 * (demo_data["data"].shape[0] % 2 != 0),
         ) + (demo_data["data"].shape[1:])
+        assert out.recon_x_indices.shape[0] == int(demo_data["data"].shape[0] / 2)
 
         assert not torch.equal(out.z, out.z_bis_permuted)
 

--- a/tests/test_FactorVAE.py
+++ b/tests/test_FactorVAE.py
@@ -322,7 +322,9 @@ class Test_Model_forward:
             int(demo_data["data"].shape[0] / 2)
             + 1 * (demo_data["data"].shape[0] % 2 != 0),
         ) + (demo_data["data"].shape[1:])
-        assert out.recon_x_indices.shape[0] == int(demo_data["data"].shape[0] / 2)
+        assert out.recon_x_indices.shape[0] == int(demo_data["data"].shape[0] / 2) + 1 * (
+            demo_data["data"].shape[0] % 2 != 0
+        )
 
         assert not torch.equal(out.z, out.z_bis_permuted)
 


### PR DESCRIPTION
Factor VAE trains by divinding the input batch into two parts randomly - to obtain z and z_bis finally.
z is reconstructed and sent back as recon_x.
However, if we would like to compare this externally with the input images, we need the randomly chosen indices (i.e. idx_1)
This PR exactly does this, by returning idx_1 as "recon_x_indices".
This does not break the existing runs, but adds just an additional output argument.