### PR TITLE
Add custom collate function

### DIFF
--- a/src/pythae/data/datasets.py
+++ b/src/pythae/data/datasets.py
@@ -8,6 +8,7 @@ from typing import Any, Tuple
 
 import torch
 from torch.utils.data import Dataset
+from torch.utils.data._utils.collate import default_collate
 
 
 class DatasetOutput(OrderedDict):
@@ -34,6 +35,15 @@ class DatasetOutput(OrderedDict):
         Convert self to a tuple containing all the attributes/keys that are not ``None``.
         """
         return tuple(self[k] for k in self.keys())
+
+
+def collate_dataset_output(batch):
+    """Collate function that treats the `DatasetOutput` class correctly."""
+    if isinstance(batch[0], DatasetOutput):
+        # `default_collate` returns a dict for older versions of PyTorch.
+        return DatasetOutput(**default_collate(batch))
+    else:
+        return default_collate(batch)
 
 
 class BaseDataset(Dataset):

--- a/src/pythae/pipelines/training.py
+++ b/src/pythae/pipelines/training.py
@@ -5,6 +5,7 @@ import numpy as np
 import torch
 
 from ..customexception import DatasetError
+from ..data.datasets import collate_dataset_output
 from ..data.preprocessors import BaseDataset, DataProcessor
 from ..models import BaseAE
 from ..trainers import *
@@ -140,7 +141,11 @@ class TrainingPipeline(Pipeline):
         # check everything if fine when combined with data loader
         from torch.utils.data import DataLoader
 
-        dataloader = DataLoader(dataset=dataset, batch_size=min(len(dataset), 2))
+        dataloader = DataLoader(
+            dataset=dataset,
+            batch_size=min(len(dataset), 2),
+            collate_fn=collate_dataset_output,
+        )
         loader_out = next(iter(dataloader))
         assert loader_out.data.shape[0] == min(
             len(dataset), 2

--- a/src/pythae/samplers/gaussian_mixture/gaussian_mixture_sampler.py
+++ b/src/pythae/samplers/gaussian_mixture/gaussian_mixture_sampler.py
@@ -4,6 +4,7 @@ import torch
 from sklearn import mixture
 from torch.utils.data import DataLoader
 
+from ...data.datasets import collate_dataset_output
 from ...data.preprocessors import DataProcessor
 from ...models import BaseAE
 from ..base import BaseSampler
@@ -60,7 +61,12 @@ class GaussianMixtureSampler(BaseSampler):
         data_processor = DataProcessor()
         train_data = data_processor.process_data(train_data).to(self.device)
         train_dataset = data_processor.to_dataset(train_data)
-        train_loader = DataLoader(dataset=train_dataset, batch_size=100, shuffle=False)
+        train_loader = DataLoader(
+            dataset=train_dataset,
+            batch_size=100,
+            shuffle=False,
+            collate_fn=collate_dataset_output,
+        )
 
         z = []
         try:

--- a/src/pythae/samplers/iaf_sampler/iaf_sampler.py
+++ b/src/pythae/samplers/iaf_sampler/iaf_sampler.py
@@ -5,6 +5,7 @@ import torch
 from torch.distributions import MultivariateNormal
 from torch.utils.data import DataLoader
 
+from ...data.datasets import collate_dataset_output
 from ...data.preprocessors import DataProcessor
 from ...models import BaseAE
 from ...models.normalizing_flows import IAF, IAFConfig, NFModel
@@ -78,7 +79,12 @@ class IAFSampler(BaseSampler):
         data_processor = DataProcessor()
         train_data = data_processor.process_data(train_data).to(self.device)
         train_dataset = data_processor.to_dataset(train_data)
-        train_loader = DataLoader(dataset=train_dataset, batch_size=100, shuffle=True)
+        train_loader = DataLoader(
+            dataset=train_dataset,
+            batch_size=100,
+            shuffle=True,
+            collate_fn=collate_dataset_output,
+        )
 
         z = []
 
@@ -109,7 +115,10 @@ class IAFSampler(BaseSampler):
             eval_data = data_processor.process_data(eval_data).to(self.device)
             eval_dataset = data_processor.to_dataset(eval_data)
             eval_loader = DataLoader(
-                dataset=eval_dataset, batch_size=100, shuffle=False
+                dataset=eval_dataset,
+                batch_size=100,
+                shuffle=False,
+                collate_fn=collate_dataset_output,
             )
 
             z = []

--- a/src/pythae/samplers/maf_sampler/maf_sampler.py
+++ b/src/pythae/samplers/maf_sampler/maf_sampler.py
@@ -5,6 +5,7 @@ import torch
 from torch.distributions import MultivariateNormal
 from torch.utils.data import DataLoader
 
+from ...data.datasets import collate_dataset_output
 from ...data.preprocessors import DataProcessor
 from ...models import BaseAE
 from ...models.normalizing_flows import MAF, MAFConfig, NFModel
@@ -78,7 +79,12 @@ class MAFSampler(BaseSampler):
         data_processor = DataProcessor()
         train_data = data_processor.process_data(train_data).to(self.device)
         train_dataset = data_processor.to_dataset(train_data)
-        train_loader = DataLoader(dataset=train_dataset, batch_size=100, shuffle=True)
+        train_loader = DataLoader(
+            dataset=train_dataset,
+            batch_size=100,
+            shuffle=True,
+            collate_fn=collate_dataset_output,
+        )
 
         z = []
 
@@ -109,7 +115,10 @@ class MAFSampler(BaseSampler):
             eval_data = data_processor.process_data(eval_data).to(self.device)
             eval_dataset = data_processor.to_dataset(eval_data)
             eval_loader = DataLoader(
-                dataset=eval_dataset, batch_size=100, shuffle=False
+                dataset=eval_dataset,
+                batch_size=100,
+                shuffle=False,
+                collate_fn=collate_dataset_output,
             )
 
             z = []

--- a/src/pythae/samplers/pixelcnn_sampler/pixelcnn_sampler.py
+++ b/src/pythae/samplers/pixelcnn_sampler/pixelcnn_sampler.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn.functional as F
 from torch.utils.data import DataLoader
 
+from ...data.datasets import collate_dataset_output
 from ...data.preprocessors import DataProcessor
 from ...models import VQVAE
 from ...models.normalizing_flows import PixelCNN, PixelCNNConfig
@@ -78,7 +79,12 @@ class PixelCNNSampler(BaseSampler):
         data_processor = DataProcessor()
         train_data = data_processor.process_data(train_data).to(self.device)
         train_dataset = data_processor.to_dataset(train_data)
-        train_loader = DataLoader(dataset=train_dataset, batch_size=100, shuffle=True)
+        train_loader = DataLoader(
+            dataset=train_dataset,
+            batch_size=100,
+            shuffle=True,
+            collate_fn=collate_dataset_output,
+        )
 
         z = []
 
@@ -106,7 +112,10 @@ class PixelCNNSampler(BaseSampler):
             eval_data = data_processor.process_data(eval_data).to(self.device)
             eval_dataset = data_processor.to_dataset(eval_data)
             eval_loader = DataLoader(
-                dataset=eval_dataset, batch_size=100, shuffle=False
+                dataset=eval_dataset,
+                batch_size=100,
+                shuffle=False,
+                collate_fn=collate_dataset_output,
             )
 
             z = []

--- a/src/pythae/samplers/two_stage_vae_sampler/two_stage_sampler.py
+++ b/src/pythae/samplers/two_stage_vae_sampler/two_stage_sampler.py
@@ -5,6 +5,7 @@ import torch
 import torch.nn as nn
 from torch.utils.data import DataLoader
 
+from ...data.datasets import collate_dataset_output
 from ...data.preprocessors import DataProcessor
 from ...models import VAE, VAEConfig
 from ...models.base.base_utils import ModelOutput
@@ -157,7 +158,12 @@ class TwoStageVAESampler(BaseSampler):
         data_processor = DataProcessor()
         train_data = data_processor.process_data(train_data).to(self.device)
         train_dataset = data_processor.to_dataset(train_data)
-        train_loader = DataLoader(dataset=train_dataset, batch_size=100, shuffle=True)
+        train_loader = DataLoader(
+            dataset=train_dataset,
+            batch_size=100,
+            shuffle=True,
+            collate_fn=collate_dataset_output,
+        )
 
         z = []
 
@@ -188,7 +194,10 @@ class TwoStageVAESampler(BaseSampler):
             eval_data = data_processor.process_data(eval_data).to(self.device)
             eval_dataset = data_processor.to_dataset(eval_data)
             eval_loader = DataLoader(
-                dataset=eval_dataset, batch_size=100, shuffle=False
+                dataset=eval_dataset,
+                batch_size=100,
+                shuffle=False,
+                collate_fn=collate_dataset_output,
             )
 
             z = []

--- a/src/pythae/trainers/base_trainer/base_trainer.py
+++ b/src/pythae/trainers/base_trainer/base_trainer.py
@@ -14,6 +14,7 @@ from torch.utils.data.distributed import DistributedSampler
 
 from ...customexception import ModelError
 from ...data.datasets import BaseDataset
+from ...data.datasets import collate_dataset_output
 from ...models import BaseAE
 from ..trainer_utils import set_seed
 from ..training_callbacks import (
@@ -177,6 +178,7 @@ class BaseTrainer:
             num_workers=self.training_config.train_dataloader_num_workers,
             shuffle=(train_sampler is None),
             sampler=train_sampler,
+            collate_fn=collate_dataset_output,
         )
 
     def get_eval_dataloader(
@@ -194,6 +196,7 @@ class BaseTrainer:
             num_workers=self.training_config.eval_dataloader_num_workers,
             shuffle=(eval_sampler is None),
             sampler=eval_sampler,
+            collate_fn=collate_dataset_output,
         )
 
     def set_optimizer(self):


### PR DESCRIPTION
When collating `DatasetOutput` objects, older versions of PyTorch return a `dict` instead of a `DatasetOutput` object.