### PR TITLE
L1 loss added to the models

### DIFF
--- a/src/pythae/models/adversarial_ae/adversarial_ae_model.py
+++ b/src/pythae/models/adversarial_ae/adversarial_ae_model.py
@@ -168,6 +168,14 @@ class Adversarial_AE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         gen_adversarial_score = self.discriminator(z).embedding.flatten()
         prior_adversarial_score = self.discriminator(z_prior).embedding.flatten()
 

--- a/src/pythae/models/base/base_model.py
+++ b/src/pythae/models/base/base_model.py
@@ -117,6 +117,26 @@ class BaseAE(nn.Module):
         """
         return self(DatasetOutput(data=inputs)).recon_x
 
+    def predict(self, inputs: BaseDataset, **kwargs) -> ModelOutput:
+        """The input data is encoded and decoded without computing loss
+        Args:
+            inputs (BaseDataset): An instance of pythae's datasets
+        Returns:
+            ModelOutput: An instance of ModelOutput containing reconstruction and embedding
+        """
+
+        x = inputs["data"]
+
+        z = self.encoder(x).embedding
+        recon_x = self.decoder(z)["reconstruction"]
+
+        output = ModelOutput(
+            recon_x=recon_x,
+            embedding=z,
+        )
+
+        return output
+
     def interpolate(
         self,
         starting_inputs: torch.Tensor,

--- a/src/pythae/models/base/base_model.py
+++ b/src/pythae/models/base/base_model.py
@@ -117,17 +117,16 @@ class BaseAE(nn.Module):
         """
         return self(DatasetOutput(data=inputs)).recon_x
 
-    def predict(self, inputs: BaseDataset, **kwargs) -> ModelOutput:
+    def predict(self, inputs: torch.Tensor) -> ModelOutput:
         """The input data is encoded and decoded without computing loss
+
         Args:
-            inputs (BaseDataset): An instance of pythae's datasets
+            inputs (torch.Tensor): The input data to be reconstructed, as well as to generate the embedding.
+
         Returns:
             ModelOutput: An instance of ModelOutput containing reconstruction and embedding
         """
-
-        x = inputs["data"]
-
-        z = self.encoder(x).embedding
+        z = self.encoder(inputs).embedding
         recon_x = self.decoder(z)["reconstruction"]
 
         output = ModelOutput(

--- a/src/pythae/models/beta_tc_vae/beta_tc_vae_model.py
+++ b/src/pythae/models/beta_tc_vae/beta_tc_vae_model.py
@@ -79,7 +79,7 @@ class BetaTCVAE(VAE):
         )
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/beta_tc_vae/beta_tc_vae_model.py
+++ b/src/pythae/models/beta_tc_vae/beta_tc_vae_model.py
@@ -106,6 +106,14 @@ class BetaTCVAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         log_q_z_given_x = self._compute_log_gauss_density(z, mu, log_var).sum(
             dim=-1
         )  # [B]

--- a/src/pythae/models/beta_vae/beta_vae_model.py
+++ b/src/pythae/models/beta_vae/beta_vae_model.py
@@ -71,7 +71,7 @@ class BetaVAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/beta_vae/beta_vae_model.py
+++ b/src/pythae/models/beta_vae/beta_vae_model.py
@@ -98,6 +98,14 @@ class BetaVAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp(), dim=-1)
 
         return (

--- a/src/pythae/models/ciwae/ciwae_model.py
+++ b/src/pythae/models/ciwae/ciwae_model.py
@@ -78,7 +78,7 @@ class CIWAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x.reshape(x.shape[0], self.n_samples, -1)[:, 0, :].reshape_as(

--- a/src/pythae/models/ciwae/ciwae_model.py
+++ b/src/pythae/models/ciwae/ciwae_model.py
@@ -113,6 +113,16 @@ class CIWAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x,
+                x.reshape(recon_x.shape[0], -1)
+                .unsqueeze(1)
+                .repeat(1, self.n_samples, 1),
+                reduction="none",
+            ).sum(dim=-1)
+
         log_q_z = (-0.5 * (log_var + torch.pow(z - mu, 2) / log_var.exp())).sum(dim=-1)
         log_p_z = -0.5 * (z ** 2).sum(dim=-1)
 

--- a/src/pythae/models/disentangled_beta_vae/disentangled_beta_vae_model.py
+++ b/src/pythae/models/disentangled_beta_vae/disentangled_beta_vae_model.py
@@ -106,6 +106,14 @@ class DisentangledBetaVAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp(), dim=-1)
         C_factor = min(epoch / (self.warmup_epoch + 1), 1)
         KLD_diff = torch.abs(KLD - self.C * C_factor)

--- a/src/pythae/models/disentangled_beta_vae/disentangled_beta_vae_model.py
+++ b/src/pythae/models/disentangled_beta_vae/disentangled_beta_vae_model.py
@@ -79,7 +79,7 @@ class DisentangledBetaVAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z, epoch)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/factor_vae/factor_vae_model.py
+++ b/src/pythae/models/factor_vae/factor_vae_model.py
@@ -151,6 +151,14 @@ class FactorVAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp(), dim=-1)
 
         latent_adversarial_score = self.discriminator(z)

--- a/src/pythae/models/info_vae/info_vae_model.py
+++ b/src/pythae/models/info_vae/info_vae_model.py
@@ -77,7 +77,7 @@ class INFOVAE_MMD(VAE):
 
         output = ModelOutput(
             loss=loss,
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld_loss,
             mmd_loss=mmd_loss,
             recon_x=recon_x,

--- a/src/pythae/models/info_vae/info_vae_model.py
+++ b/src/pythae/models/info_vae/info_vae_model.py
@@ -106,6 +106,14 @@ class INFOVAE_MMD(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp(), dim=-1)
 
         if self.kernel_choice == "rbf":

--- a/src/pythae/models/iwae/iwae_model.py
+++ b/src/pythae/models/iwae/iwae_model.py
@@ -77,7 +77,7 @@ class IWAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x.reshape(x.shape[0], self.n_samples, -1)[:, 0, :].reshape_as(

--- a/src/pythae/models/iwae/iwae_model.py
+++ b/src/pythae/models/iwae/iwae_model.py
@@ -112,6 +112,16 @@ class IWAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x,
+                x.reshape(recon_x.shape[0], -1)
+                .unsqueeze(1)
+                .repeat(1, self.n_samples, 1),
+                reduction="none",
+            ).sum(dim=-1)
+
         log_q_z = (-0.5 * (log_var + torch.pow(z - mu, 2) / log_var.exp())).sum(dim=-1)
         log_p_z = -0.5 * (z ** 2).sum(dim=-1)
 

--- a/src/pythae/models/miwae/miwae_model.py
+++ b/src/pythae/models/miwae/miwae_model.py
@@ -86,7 +86,7 @@ class MIWAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x.reshape(

--- a/src/pythae/models/miwae/miwae_model.py
+++ b/src/pythae/models/miwae/miwae_model.py
@@ -123,6 +123,17 @@ class MIWAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x,
+                x.reshape(recon_x.shape[0], -1)
+                .unsqueeze(1)
+                .unsqueeze(1)
+                .repeat(1, self.gradient_n_estimates, self.n_samples, 1),
+                reduction="none",
+            ).sum(dim=-1)
+
         log_q_z = (-0.5 * (log_var + torch.pow(z - mu, 2) / log_var.exp())).sum(dim=-1)
         log_p_z = -0.5 * (z ** 2).sum(dim=-1)
 

--- a/src/pythae/models/msssim_vae/msssim_vae_model.py
+++ b/src/pythae/models/msssim_vae/msssim_vae_model.py
@@ -72,7 +72,7 @@ class MSSSIM_VAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/piwae/piwae_model.py
+++ b/src/pythae/models/piwae/piwae_model.py
@@ -90,7 +90,7 @@ class PIWAE(VAE):
         loss = miwae_loss + iwae_loss
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             encoder_loss=miwae_loss,

--- a/src/pythae/models/piwae/piwae_model.py
+++ b/src/pythae/models/piwae/piwae_model.py
@@ -131,6 +131,17 @@ class PIWAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x,
+                x.reshape(recon_x.shape[0], -1)
+                .unsqueeze(1)
+                .unsqueeze(1)
+                .repeat(1, self.gradient_n_estimates, self.n_samples, 1),
+                reduction="none",
+            ).sum(dim=-1)
+
         log_q_z = (-0.5 * (log_var + torch.pow(z - mu, 2) / log_var.exp())).sum(dim=-1)
         log_p_z = -0.5 * (z ** 2).sum(dim=-1)
 

--- a/src/pythae/models/pvae/pvae_model.py
+++ b/src/pythae/models/pvae/pvae_model.py
@@ -115,7 +115,7 @@ class PoincareVAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, z, qz_x)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/pvae/pvae_model.py
+++ b/src/pythae/models/pvae/pvae_model.py
@@ -142,6 +142,14 @@ class PoincareVAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         pz = self.prior(
             loc=self._pz_mu, scale=self._pz_logvar.exp(), manifold=self.latent_manifold
         )
@@ -277,6 +285,18 @@ class PoincareVAE(VAE):
                         x_rep.reshape(x_rep.shape[0], -1),
                         reduction="none",
                     ).sum(dim=-1)
+
+                elif self.model_config.reconstruction_loss == "l1":
+
+                    log_p_x_given_z = -0.5 * F.l1_loss(
+                        recon_x.reshape(x_rep.shape[0], -1),
+                        x_rep.reshape(x_rep.shape[0], -1),
+                        reduction="none",
+                    ).sum(dim=-1) - torch.tensor(
+                        [np.prod(self.input_dim) / 2 * np.log(np.pi * 2)]
+                    ).to(
+                        data.device
+                    )  # decoding distribution is assumed unit variance  N(mu, I)
 
                 log_p_x.append(log_p_x_given_z + log_p_z - log_q_z_given_x)
 

--- a/src/pythae/models/svae/svae_model.py
+++ b/src/pythae/models/svae/svae_model.py
@@ -115,6 +115,14 @@ class SVAE(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         KLD = self._compute_kl(m=loc.shape[-1], concentration=concentration)
 
         return (recon_loss + KLD).mean(dim=0), recon_loss.mean(dim=0), KLD.mean(dim=0)
@@ -285,6 +293,18 @@ class SVAE(VAE):
                         x_rep.reshape(x_rep.shape[0], -1),
                         reduction="none",
                     ).sum(dim=-1)
+
+                elif self.model_config.reconstruction_loss == "l1":
+
+                    log_p_x_given_z = -0.5 * F.l1_loss(
+                        recon_x.reshape(x_rep.shape[0], -1),
+                        x_rep.reshape(x_rep.shape[0], -1),
+                        reduction="none",
+                    ).sum(dim=-1) - torch.tensor(
+                        [np.prod(self.input_dim) / 2 * np.log(np.pi * 2)]
+                    ).to(
+                        data.device
+                    )  # decoding distribution is assumed unit variance  N(mu, I)
 
                 log_p_x.append(
                     log_p_x_given_z + log_p_z - log_q_z_given_x

--- a/src/pythae/models/svae/svae_model.py
+++ b/src/pythae/models/svae/svae_model.py
@@ -147,7 +147,8 @@ class SVAE(VAE):
 
         w = self._acc_rej_steps(m=loc.shape[-1], k=concentration)
 
-        z = torch.cat((w, (1 - w ** 2).sqrt() * v), dim=-1)
+        w_ = torch.sqrt(torch.clamp(1 - (w ** 2), 1e-10))
+        z = torch.cat((w, w_ * v), dim=-1)
 
         return self._householder_rotation(loc, z)
 

--- a/src/pythae/models/svae/svae_model.py
+++ b/src/pythae/models/svae/svae_model.py
@@ -88,7 +88,7 @@ class SVAE(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, loc, concentration, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vae/vae_model.py
+++ b/src/pythae/models/vae/vae_model.py
@@ -88,7 +88,7 @@ class VAE(BaseAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vae/vae_model.py
+++ b/src/pythae/models/vae/vae_model.py
@@ -115,6 +115,14 @@ class VAE(BaseAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         KLD = -0.5 * torch.sum(1 + log_var - mu.pow(2) - log_var.exp(), dim=-1)
 
         return (recon_loss + KLD).mean(dim=0), recon_loss.mean(dim=0), KLD.mean(dim=0)
@@ -185,6 +193,18 @@ class VAE(BaseAE):
                         x_rep.reshape(x_rep.shape[0], -1),
                         reduction="none",
                     ).sum(dim=-1)
+
+                elif self.model_config.reconstruction_loss == "l1":
+
+                    log_p_x_given_z = -0.5 * F.l1_loss(
+                        recon_x.reshape(x_rep.shape[0], -1),
+                        x_rep.reshape(x_rep.shape[0], -1),
+                        reduction="none",
+                    ).sum(dim=-1) - torch.tensor(
+                        [np.prod(self.input_dim) / 2 * np.log(np.pi * 2)]
+                    ).to(
+                        data.device
+                    )  # decoding distribution is assumed unit variance  N(mu, I)
 
                 log_p_x.append(
                     log_p_x_given_z + log_p_z - log_q_z_given_x

--- a/src/pythae/models/vae_iaf/vae_iaf_model.py
+++ b/src/pythae/models/vae_iaf/vae_iaf_model.py
@@ -93,7 +93,7 @@ class VAE_IAF(VAE):
         )
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vae_iaf/vae_iaf_model.py
+++ b/src/pythae/models/vae_iaf/vae_iaf_model.py
@@ -120,6 +120,14 @@ class VAE_IAF(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         # starting gaussian log-density
         log_prob_z0 = (
             -0.5 * (log_var + torch.pow(z0 - mu, 2) / torch.exp(log_var))
@@ -211,6 +219,18 @@ class VAE_IAF(VAE):
                         x_rep.reshape(x_rep.shape[0], -1),
                         reduction="none",
                     ).sum(dim=-1)
+
+                elif self.model_config.reconstruction_loss == "l1":
+
+                    log_p_x_given_z = -0.5 * F.l1_loss(
+                        recon_x.reshape(x_rep.shape[0], -1),
+                        x_rep.reshape(x_rep.shape[0], -1),
+                        reduction="none",
+                    ).sum(dim=-1) - torch.tensor(
+                        [np.prod(self.input_dim) / 2 * np.log(np.pi * 2)]
+                    ).to(
+                        data.device
+                    )  # decoding distribution is assumed unit variance  N(mu, I)
 
                 log_p_x.append(
                     log_p_x_given_z + log_p_z - log_q_z_given_x

--- a/src/pythae/models/vae_lin_nf/vae_lin_nf_model.py
+++ b/src/pythae/models/vae_lin_nf/vae_lin_nf_model.py
@@ -106,7 +106,7 @@ class VAE_LinNF(VAE):
         )
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vae_lin_nf/vae_lin_nf_model.py
+++ b/src/pythae/models/vae_lin_nf/vae_lin_nf_model.py
@@ -133,6 +133,14 @@ class VAE_LinNF(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         # starting gaussian log-density
         log_prob_z0 = (
             -0.5 * (log_var + torch.pow(z0 - mu, 2) / torch.exp(log_var))
@@ -225,6 +233,18 @@ class VAE_LinNF(VAE):
                         x_rep.reshape(x_rep.shape[0], -1),
                         reduction="none",
                     ).sum(dim=-1)
+
+                elif self.model_config.reconstruction_loss == "l1":
+
+                    log_p_x_given_z = -0.5 * F.l1_loss(
+                        recon_x.reshape(x_rep.shape[0], -1),
+                        x_rep.reshape(x_rep.shape[0], -1),
+                        reduction="none",
+                    ).sum(dim=-1) - torch.tensor(
+                        [np.prod(self.input_dim) / 2 * np.log(np.pi * 2)]
+                    ).to(
+                        data.device
+                    )  # decoding distribution is assumed unit variance  N(mu, I)
 
                 log_p_x.append(
                     log_p_x_given_z + log_p_z - log_q_z_given_x

--- a/src/pythae/models/vamp/vamp_model.py
+++ b/src/pythae/models/vamp/vamp_model.py
@@ -91,7 +91,7 @@ class VAMP(VAE):
         loss, recon_loss, kld = self.loss_function(recon_x, x, mu, log_var, z, epoch)
 
         output = ModelOutput(
-            reconstruction_loss=recon_loss,
+            recon_loss=recon_loss,
             reg_loss=kld,
             loss=loss,
             recon_x=recon_x,

--- a/src/pythae/models/vamp/vamp_model.py
+++ b/src/pythae/models/vamp/vamp_model.py
@@ -118,6 +118,14 @@ class VAMP(VAE):
                 reduction="none",
             ).sum(dim=-1)
 
+        elif self.model_config.reconstruction_loss == "l1":
+
+            recon_loss = F.l1_loss(
+                recon_x.reshape(x.shape[0], -1),
+                x.reshape(x.shape[0], -1),
+                reduction="none",
+            ).sum(dim=-1)
+
         log_p_z = self._log_p_z(z)
 
         log_q_z = (-0.5 * (log_var + torch.pow(z - mu, 2) / log_var.exp())).sum(dim=1)
@@ -242,6 +250,18 @@ class VAMP(VAE):
                         x_rep.reshape(x_rep.shape[0], -1),
                         reduction="none",
                     ).sum(dim=-1)
+
+                elif self.model_config.reconstruction_loss == "l1":
+
+                    log_p_x_given_z = -0.5 * F.l1_loss(
+                        recon_x.reshape(x_rep.shape[0], -1),
+                        x_rep.reshape(x_rep.shape[0], -1),
+                        reduction="none",
+                    ).sum(dim=-1) - torch.tensor(
+                        [np.prod(self.input_dim) / 2 * np.log(np.pi * 2)]
+                    ).to(
+                        data.device
+                    )  # decoding distribution is assumed unit variance  N(mu, I)
 
                 log_p_x.append(
                     log_p_x_given_z + log_p_z - log_q_z_given_x

--- a/tests/test_AE.py
+++ b/tests/test_AE.py
@@ -376,8 +376,7 @@ class Test_Model_predict:
     def test_predict(self, ae, demo_data):
 
         model_output = ae.predict(demo_data)
-        assert tuple(model_output.recon_x.shape) == demo_data.shape
-        assert tuple(model_output.embedding.shape) == ae.model_config.latent_dim.shape
+        assert tuple(model_output.embedding.shape) == (demo_data.shape[0], ae.model_config.latent_dim)
 
 @pytest.mark.slow
 class Test_AE_Training:

--- a/tests/test_AE.py
+++ b/tests/test_AE.py
@@ -355,6 +355,29 @@ class Test_Model_reconstruct:
         recon = ae.reconstruct(demo_data)
         assert tuple(recon.shape) == demo_data.shape
 
+class Test_Model_predict:
+    @pytest.fixture(
+        params=[
+            torch.randn(3, 2, 3, 1),
+            torch.randn(3, 2, 2),
+            torch.load(os.path.join(PATH, "data/mnist_clean_train_dataset_sample"))[:][
+                "data"
+            ],
+        ]
+    )
+    def demo_data(self, request):
+        return request.param
+
+    @pytest.fixture()
+    def ae(self, model_configs, demo_data):
+        model_configs.input_dim = tuple(demo_data[0].shape)
+        return AE(model_configs)
+
+    def test_predict(self, ae, demo_data):
+
+        model_output = ae.predict(demo_data)
+        assert tuple(model_output.recon_x.shape) == demo_data.shape
+        assert tuple(model_output.embedding.shape) == ae.model_config.latent_dim.shape
 
 @pytest.mark.slow
 class Test_AE_Training:

--- a/tests/test_Adversarial_AE.py
+++ b/tests/test_Adversarial_AE.py
@@ -43,6 +43,9 @@ def model_configs_no_input_dim(request):
         Adversarial_AE_Config(
             input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"
         ),
+        Adversarial_AE_Config(
+            input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"
+        ),
         Adversarial_AE_Config(input_dim=(1, 2, 18), latent_dim=5),
     ]
 )

--- a/tests/test_BetaTCVAE.py
+++ b/tests/test_BetaTCVAE.py
@@ -298,7 +298,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_BetaTCVAE.py
+++ b/tests/test_BetaTCVAE.py
@@ -41,6 +41,9 @@ def model_configs_no_input_dim(request):
             input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"
         ),
         BetaTCVAEConfig(
+            input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"
+        ),
+        BetaTCVAEConfig(
             input_dim=(1, 28), latent_dim=5, beta=5.2, alpha=10, gamma=2, use_mss=False
         ),
     ]

--- a/tests/test_BetaVAE.py
+++ b/tests/test_BetaVAE.py
@@ -33,6 +33,7 @@ def model_configs_no_input_dim(request):
 @pytest.fixture(
     params=[
         BetaVAEConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"),
+        BetaVAEConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"),
         BetaVAEConfig(input_dim=(1, 28), latent_dim=5, beta=5.2),
     ]
 )

--- a/tests/test_BetaVAE.py
+++ b/tests/test_BetaVAE.py
@@ -289,7 +289,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_CIWAE.py
+++ b/tests/test_CIWAE.py
@@ -38,6 +38,11 @@ def model_configs_no_input_dim(request):
             reconstruction_loss="bce",
             number_samples=2,
         ),
+        CIWAEConfig(
+            input_dim=(1, 28, 28),
+            latent_dim=10,
+            reconstruction_loss="l1"
+        ),
         CIWAEConfig(input_dim=(1, 28), latent_dim=5),
     ]
 )

--- a/tests/test_CIWAE.py
+++ b/tests/test_CIWAE.py
@@ -297,7 +297,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_DisentangledBetaVAE.py
+++ b/tests/test_DisentangledBetaVAE.py
@@ -308,7 +308,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_DisentangledBetaVAE.py
+++ b/tests/test_DisentangledBetaVAE.py
@@ -41,6 +41,9 @@ def model_configs_no_input_dim(request):
             input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"
         ),
         DisentangledBetaVAEConfig(
+            input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"
+        ),
+        DisentangledBetaVAEConfig(
             input_dim=(1, 28), latent_dim=5, beta=5.2, warmup_epoch=0
         ),
     ]

--- a/tests/test_FactorVAE.py
+++ b/tests/test_FactorVAE.py
@@ -42,6 +42,9 @@ def model_configs_no_input_dim(request):
         FactorVAEConfig(
             input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"
         ),
+        FactorVAEConfig(
+            input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"
+        ),
         FactorVAEConfig(input_dim=(1, 2, 18), latent_dim=5, gamma=10),
     ]
 )

--- a/tests/test_IWAE.py
+++ b/tests/test_IWAE.py
@@ -45,6 +45,11 @@ def model_configs_no_input_dim(request):
             reconstruction_loss="bce",
             number_samples=2,
         ),
+        IWAEConfig(
+            input_dim=(1, 28, 28),
+            latent_dim=10,
+            reconstruction_loss="l1"
+        ),
         IWAEConfig(input_dim=(1, 28), latent_dim=5),
     ]
 )

--- a/tests/test_IWAE.py
+++ b/tests/test_IWAE.py
@@ -301,7 +301,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_MIWAE.py
+++ b/tests/test_MIWAE.py
@@ -296,7 +296,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_MIWAE.py
+++ b/tests/test_MIWAE.py
@@ -40,6 +40,11 @@ def model_configs_no_input_dim(request):
             reconstruction_loss="bce",
             number_samples=2,
         ),
+        MIWAEConfig(
+            input_dim=(1, 28, 28),
+            latent_dim=10,
+            reconstruction_loss="l1"
+        ),
         MIWAEConfig(input_dim=(1, 28), latent_dim=5),
     ]
 )

--- a/tests/test_MSSSIMVAE.py
+++ b/tests/test_MSSSIMVAE.py
@@ -37,6 +37,9 @@ def model_configs_no_input_dim(request):
         MSSSIM_VAEConfig(
             input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"
         ),
+        MSSSIM_VAEConfig(
+            input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"
+        ),
         MSSSIM_VAEConfig(input_dim=(1, 28), latent_dim=5, beta=5.2),
     ]
 )

--- a/tests/test_MSSSIMVAE.py
+++ b/tests/test_MSSSIMVAE.py
@@ -299,7 +299,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_PIWAE.py
+++ b/tests/test_PIWAE.py
@@ -296,7 +296,7 @@ class Test_Model_forward:
             set(
                 [
                     "loss",
-                    "reconstruction_loss",
+                    "recon_loss",
                     "encoder_loss",
                     "decoder_loss",
                     "update_encoder",

--- a/tests/test_PIWAE.py
+++ b/tests/test_PIWAE.py
@@ -36,6 +36,8 @@ def model_configs_no_input_dim(request):
 @pytest.fixture(
     params=[
         PIWAEConfig(input_dim=(1, 28, 28), latent_dim=10, number_gradient_estimates=3),
+        PIWAEConfig(input_dim=(1, 28, 28), latent_dim=10, number_gradient_estimates=3, reconstruction_loss="bce"),
+        PIWAEConfig(input_dim=(1, 28, 28), latent_dim=10, number_gradient_estimates=3, reconstruction_loss="l1"),
         PIWAEConfig(input_dim=(1, 2, 18), latent_dim=5),
     ]
 )

--- a/tests/test_PoincareVAE.py
+++ b/tests/test_PoincareVAE.py
@@ -54,6 +54,14 @@ def model_configs_no_input_dim(request):
             curvature=0.7,
         ),
         PoincareVAEConfig(
+            input_dim=(1, 28, 28),
+            latent_dim=2,
+            reconstruction_loss="l1",
+            prior_distribution="wrapped_normal",
+            posterior_distribution="wrapped_normal",
+            curvature=0.7,
+        ),
+        PoincareVAEConfig(
             input_dim=(1, 28),
             latent_dim=5,
             prior_distribution="riemannian_normal",

--- a/tests/test_PoincareVAE.py
+++ b/tests/test_PoincareVAE.py
@@ -334,7 +334,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_RHVAE.py
+++ b/tests/test_RHVAE.py
@@ -38,6 +38,9 @@ def model_configs_no_input_dim(request):
         RHVAEConfig(
             input_dim=(1, 28, 28), latent_dim=1, n_lf=1, reconstruction_loss="bce"
         ),
+        RHVAEConfig(
+            input_dim=(1, 28, 28), latent_dim=1, n_lf=1, reconstruction_loss="l1"
+        ),
         RHVAEConfig(input_dim=(1, 2, 18), latent_dim=2, n_lf=1),
     ]
 )

--- a/tests/test_SVAE.py
+++ b/tests/test_SVAE.py
@@ -283,7 +283,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_SVAE.py
+++ b/tests/test_SVAE.py
@@ -27,6 +27,7 @@ def model_configs_no_input_dim(request):
 @pytest.fixture(
     params=[
         SVAEConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"),
+        SVAEConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"),
         SVAEConfig(input_dim=(1, 28), latent_dim=5),
     ]
 )

--- a/tests/test_VAE.py
+++ b/tests/test_VAE.py
@@ -289,7 +289,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_VAE.py
+++ b/tests/test_VAE.py
@@ -33,6 +33,7 @@ def model_configs_no_input_dim(request):
 @pytest.fixture(
     params=[
         VAEConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"),
+        VAEConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"),
         VAEConfig(input_dim=(1, 28), latent_dim=5),
     ]
 )

--- a/tests/test_VAEGAN.py
+++ b/tests/test_VAEGAN.py
@@ -42,6 +42,7 @@ def model_configs_no_input_dim(request):
 @pytest.fixture(
     params=[
         VAEGANConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"),
+        VAEGANConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"),
         VAEGANConfig(input_dim=(1, 2, 18), latent_dim=5, reconstruction_layer=1),
     ]
 )

--- a/tests/test_VAE_IAF.py
+++ b/tests/test_VAE_IAF.py
@@ -33,6 +33,7 @@ def model_configs_no_input_dim(request):
 @pytest.fixture(
     params=[
         VAE_IAF_Config(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"),
+        VAE_IAF_Config(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"),
         VAE_IAF_Config(
             input_dim=(1, 28),
             latent_dim=5,

--- a/tests/test_VAE_IAF.py
+++ b/tests/test_VAE_IAF.py
@@ -295,7 +295,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_VAE_LinFlow.py
+++ b/tests/test_VAE_LinFlow.py
@@ -309,7 +309,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_VAE_LinFlow.py
+++ b/tests/test_VAE_LinFlow.py
@@ -39,6 +39,12 @@ def model_configs_no_input_dim(request):
             flows=["Planar", "Radial", "Planar"],
         ),
         VAE_LinNF_Config(
+            input_dim=(1, 28, 28),
+            latent_dim=10,
+            reconstruction_loss="l1",
+            flows=["Planar", "Radial", "Planar"],
+        ),
+        VAE_LinNF_Config(
             input_dim=(1, 28), latent_dim=5, flows=["Radial", "Radial", "Radial"]
         ),
     ]

--- a/tests/test_VAMP.py
+++ b/tests/test_VAMP.py
@@ -27,6 +27,7 @@ def model_configs_no_input_dim(request):
 @pytest.fixture(
     params=[
         VAMPConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"),
+        VAMPConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="l1"),
         VAMPConfig(input_dim=(1, 2, 18), number_components=10, latent_dim=5),
     ]
 )

--- a/tests/test_VAMP.py
+++ b/tests/test_VAMP.py
@@ -287,7 +287,7 @@ class Test_Model_forward:
 
         assert isinstance(out, ModelOutput)
 
-        assert set(["reconstruction_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
+        assert set(["recon_loss", "reg_loss", "loss", "recon_x", "z"]) == set(
             out.keys()
         )
 

--- a/tests/test_info_vae_mmd.py
+++ b/tests/test_info_vae_mmd.py
@@ -301,7 +301,7 @@ class Test_Model_forward:
         assert isinstance(out, ModelOutput)
 
         assert set(
-            ["reconstruction_loss", "reg_loss", "loss", "mmd_loss", "recon_x", "z"]
+            ["recon_loss", "reg_loss", "loss", "mmd_loss", "recon_x", "z"]
         ) == set(out.keys())
 
         assert out.z.shape[0] == demo_data["data"].shape[0]

--- a/tests/test_info_vae_mmd.py
+++ b/tests/test_info_vae_mmd.py
@@ -38,6 +38,11 @@ def model_configs_no_input_dim(request):
             reconstruction_loss="bce",
             kernel_choice="rbf",
         ),
+        INFOVAE_MMD_Config(
+            input_dim=(1, 28, 28),
+            latent_dim=10,
+            reconstruction_loss="l1"
+        ),
         INFOVAE_MMD_Config(input_dim=(1, 28), latent_dim=5, lbd=5.2, alpha=0.2),
     ]
 )


### PR DESCRIPTION
MSE loss sometimes make the models produce smooth images. L1 loss is an easy drop-in fix for the same. I have added to the models where we already had MSE and BCE loss functions, and skipped (for now) the ones without the recon loss flag. In the futurue, I will also add a feature to pass custom loss functions. 