### PR TITLE
Add AMP support to BaseTrainer

### DIFF
--- a/src/pythae/trainers/base_trainer/base_trainer.py
+++ b/src/pythae/trainers/base_trainer/base_trainer.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 import os
+import contextlib
 from copy import deepcopy
 from typing import Any, Dict, List, Optional
 
@@ -93,6 +94,8 @@ class BaseTrainer:
                 if torch.cuda.is_available() and not self.training_config.no_cuda
                 else "cpu"
             )
+
+        self.amp_context = torch.autocast if self.training_config.amp else contextlib.nullcontext
 
         self.device = device
 
@@ -534,13 +537,22 @@ class BaseTrainer:
 
         epoch_loss = 0
 
-        for inputs in self.eval_loader:
+        with self.amp_context():
+            for inputs in self.eval_loader:
 
-            inputs = self._set_inputs_to_device(inputs)
+                inputs = self._set_inputs_to_device(inputs)
 
-            try:
-                with torch.no_grad():
+                try:
+                    with torch.no_grad():
 
+                        model_output = self.model(
+                            inputs,
+                            epoch=epoch,
+                            dataset_size=len(self.eval_loader.dataset),
+                            uses_ddp=self.distributed,
+                        )
+
+                except RuntimeError:
                     model_output = self.model(
                         inputs,
                         epoch=epoch,
@@ -548,22 +560,14 @@ class BaseTrainer:
                         uses_ddp=self.distributed,
                     )
 
-            except RuntimeError:
-                model_output = self.model(
-                    inputs,
-                    epoch=epoch,
-                    dataset_size=len(self.eval_loader.dataset),
-                    uses_ddp=self.distributed,
-                )
+                loss = model_output.loss
 
-            loss = model_output.loss
+                epoch_loss += loss.item()
 
-            epoch_loss += loss.item()
+                if epoch_loss != epoch_loss:
+                    raise ArithmeticError("NaN detected in eval loss")
 
-            if epoch_loss != epoch_loss:
-                raise ArithmeticError("NaN detected in eval loss")
-
-            self.callback_handler.on_eval_step_end(training_config=self.training_config)
+                self.callback_handler.on_eval_step_end(training_config=self.training_config)
 
         epoch_loss /= len(self.eval_loader)
 
@@ -594,12 +598,13 @@ class BaseTrainer:
 
             inputs = self._set_inputs_to_device(inputs)
 
-            model_output = self.model(
-                inputs,
-                epoch=epoch,
-                dataset_size=len(self.train_loader.dataset),
-                uses_ddp=self.distributed,
-            )
+            with self.amp_context():
+                model_output = self.model(
+                    inputs,
+                    epoch=epoch,
+                    dataset_size=len(self.train_loader.dataset),
+                    uses_ddp=self.distributed,
+                )
 
             self._optimizers_step(model_output)
 
@@ -686,19 +691,20 @@ class BaseTrainer:
 
         model.eval()
 
-        inputs = next(iter(self.eval_loader))
-        inputs = self._set_inputs_to_device(inputs)
+        with self.amp_context():
+            inputs = next(iter(self.eval_loader))
+            inputs = self._set_inputs_to_device(inputs)
 
-        model_out = model(inputs)
-        reconstructions = model_out.recon_x.cpu().detach()[
-            : min(inputs["data"].shape[0], 10)
-        ]
-        z_enc = model_out.z[: min(inputs["data"].shape[0], 10)]
-        z = torch.randn_like(z_enc)
-        if self.distributed:
-            normal_generation = model.module.decoder(z).reconstruction.detach().cpu()
-        else:
-            normal_generation = model.decoder(z).reconstruction.detach().cpu()
+            model_out = model(inputs)
+            reconstructions = model_out.recon_x.cpu().detach()[
+                : min(inputs["data"].shape[0], 10)
+            ]
+            z_enc = model_out.z[: min(inputs["data"].shape[0], 10)]
+            z = torch.randn_like(z_enc)
+            if self.distributed:
+                normal_generation = model.module.decoder(z).reconstruction.detach().cpu()
+            else:
+                normal_generation = model.decoder(z).reconstruction.detach().cpu()
 
         return (
             inputs["data"][: min(inputs["data"].shape[0], 10)],

--- a/src/pythae/trainers/base_trainer/base_trainer.py
+++ b/src/pythae/trainers/base_trainer/base_trainer.py
@@ -100,7 +100,10 @@ class BaseTrainer:
             else contextlib.nullcontext()
         )
 
-        if model.model_config.reconstruction_loss == "bce":
+        if (
+            hasattr(model.model_config, "reconstruction_loss")
+            and model.model_config.reconstruction_loss == "bce"
+        ):
             self.amp_context = contextlib.nullcontext()
 
         self.device = device

--- a/src/pythae/trainers/base_trainer/base_trainer.py
+++ b/src/pythae/trainers/base_trainer/base_trainer.py
@@ -95,7 +95,7 @@ class BaseTrainer:
                 else "cpu"
             )
 
-        self.amp_context = torch.autocast if self.training_config.amp else contextlib.nullcontext
+        self.amp_context = torch.autocast("cuda") if self.training_config.amp else contextlib.nullcontext()
 
         self.device = device
 
@@ -537,7 +537,7 @@ class BaseTrainer:
 
         epoch_loss = 0
 
-        with self.amp_context():
+        with self.amp_context:
             for inputs in self.eval_loader:
 
                 inputs = self._set_inputs_to_device(inputs)
@@ -598,7 +598,7 @@ class BaseTrainer:
 
             inputs = self._set_inputs_to_device(inputs)
 
-            with self.amp_context():
+            with self.amp_context:
                 model_output = self.model(
                     inputs,
                     epoch=epoch,
@@ -691,7 +691,7 @@ class BaseTrainer:
 
         model.eval()
 
-        with self.amp_context():
+        with self.amp_context:
             inputs = next(iter(self.eval_loader))
             inputs = self._set_inputs_to_device(inputs)
 

--- a/src/pythae/trainers/base_trainer/base_training_config.py
+++ b/src/pythae/trainers/base_trainer/base_training_config.py
@@ -48,6 +48,7 @@ class BaseTrainerConfig(BaseConfig):
         dist_backend (str): The distributed backend to use. Default: 'nccl'
         master_addr (str): The master address for distributed training. Default: 'localhost'
         master_port (str): The master port for distributed training. Default: '12345'
+        amp (bool): Whether to use auto mixed precision in training. Default: False
     """
 
     output_dir: str = None
@@ -72,6 +73,7 @@ class BaseTrainerConfig(BaseConfig):
     dist_backend: str = field(default="nccl")
     master_addr: str = field(default="localhost")
     master_port: str = field(default="12345")
+    amp: bool = False
 
     def __post_init__(self):
         super().__post_init__()
@@ -149,3 +151,6 @@ class BaseTrainerConfig(BaseConfig):
                         f"Got {self.scheduler_params} as parameters.\n"
                         f"Exception raised: {type(e)} with message: " + str(e)
                     ) from e
+
+        if self.no_cuda:
+            self.amp = False

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -33,7 +33,7 @@ def model_configs_no_input_dim(request):
 @pytest.fixture(
     params=[
         VAEConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"),
-        VAEConfig(input_dim=(1, 28), latent_dim=5),
+        VAEConfig(input_dim=(1, 28, 28), latent_dim=5),
     ]
 )
 def model_configs(request):

--- a/tests/test_amp.py
+++ b/tests/test_amp.py
@@ -1,0 +1,235 @@
+import os
+from copy import deepcopy
+
+import pytest
+import torch
+
+from pythae.customexception import BadInheritanceError
+from pythae.models import VAE, AutoModel, VAEConfig
+from pythae.models.base.base_utils import ModelOutput
+from pythae.pipelines import GenerationPipeline, TrainingPipeline
+from pythae.samplers import (
+    GaussianMixtureSamplerConfig,
+    IAFSamplerConfig,
+    MAFSamplerConfig,
+    NormalSamplerConfig,
+    TwoStageVAESamplerConfig,
+)
+from pythae.trainers import BaseTrainer, BaseTrainerConfig
+from tests.data.custom_architectures import (
+    Decoder_AE_Conv,
+    Encoder_VAE_Conv,
+    NetBadInheritance,
+)
+
+PATH = os.path.dirname(os.path.abspath(__file__))
+
+
+@pytest.fixture(params=[VAEConfig(), VAEConfig(latent_dim=5)])
+def model_configs_no_input_dim(request):
+    return request.param
+
+
+@pytest.fixture(
+    params=[
+        VAEConfig(input_dim=(1, 28, 28), latent_dim=10, reconstruction_loss="bce"),
+        VAEConfig(input_dim=(1, 28), latent_dim=5),
+    ]
+)
+def model_configs(request):
+    return request.param
+
+
+@pytest.fixture
+def custom_encoder(model_configs):
+    return Encoder_VAE_Conv(model_configs)
+
+
+@pytest.fixture
+def custom_decoder(model_configs):
+    return Decoder_AE_Conv(model_configs)
+
+
+@pytest.mark.slow
+class Test_VAE_Training:
+    @pytest.fixture
+    def train_dataset(self):
+        return torch.load(os.path.join(PATH, "data/mnist_clean_train_dataset_sample"))
+
+    @pytest.fixture(
+        params=[BaseTrainerConfig(num_epochs=3, steps_saving=2, learning_rate=1e-5, amp=True)]
+    )
+    def training_configs(self, tmpdir, request):
+        tmpdir.mkdir("dummy_folder")
+        dir_path = os.path.join(tmpdir, "dummy_folder")
+        request.param.output_dir = dir_path
+        return request.param
+
+    @pytest.fixture(
+        params=[
+            torch.rand(1),
+            torch.rand(1),
+            torch.rand(1),
+            torch.rand(1),
+            torch.rand(1),
+        ]
+    )
+    def vae(self, model_configs, custom_encoder, custom_decoder, request):
+        # randomized
+
+        alpha = request.param
+
+        if alpha < 0.25:
+            model = VAE(model_configs)
+
+        elif 0.25 <= alpha < 0.5:
+            model = VAE(model_configs, encoder=custom_encoder)
+
+        elif 0.5 <= alpha < 0.75:
+            model = VAE(model_configs, decoder=custom_decoder)
+
+        else:
+            model = VAE(model_configs, encoder=custom_encoder, decoder=custom_decoder)
+
+        return model
+
+    @pytest.fixture
+    def trainer(self, vae, train_dataset, training_configs):
+        trainer = BaseTrainer(
+            model=vae,
+            train_dataset=train_dataset,
+            eval_dataset=train_dataset,
+            training_config=training_configs,
+        )
+
+        trainer.prepare_training()
+
+        return trainer
+
+    def test_vae_train_step(self, trainer):
+
+        start_model_state_dict = deepcopy(trainer.model.state_dict())
+
+        step_1_loss = trainer.train_step(epoch=1)
+
+        step_1_model_state_dict = deepcopy(trainer.model.state_dict())
+
+        # check that weights were updated
+        assert not all(
+            [
+                torch.equal(start_model_state_dict[key], step_1_model_state_dict[key])
+                for key in start_model_state_dict.keys()
+            ]
+        )
+
+    def test_vae_eval_step(self, trainer):
+
+        start_model_state_dict = deepcopy(trainer.model.state_dict())
+
+        step_1_loss = trainer.eval_step(epoch=1)
+
+        step_1_model_state_dict = deepcopy(trainer.model.state_dict())
+
+        # check that weights were not updated
+        assert all(
+            [
+                torch.equal(start_model_state_dict[key], step_1_model_state_dict[key])
+                for key in start_model_state_dict.keys()
+            ]
+        )
+
+    def test_vae_predict_step(self, trainer, train_dataset):
+
+        start_model_state_dict = deepcopy(trainer.model.state_dict())
+
+        inputs, recon, generated = trainer.predict(trainer.model)
+
+        step_1_model_state_dict = deepcopy(trainer.model.state_dict())
+
+        # check that weights were not updated
+        assert all(
+            [
+                torch.equal(start_model_state_dict[key], step_1_model_state_dict[key])
+                for key in start_model_state_dict.keys()
+            ]
+        )
+
+        assert inputs.cpu() in train_dataset.data
+        assert recon.shape == inputs.shape
+        assert generated.shape == inputs.shape
+
+    def test_vae_main_train_loop(self, trainer):
+
+        start_model_state_dict = deepcopy(trainer.model.state_dict())
+
+        trainer.train()
+
+        step_1_model_state_dict = deepcopy(trainer.model.state_dict())
+
+        # check that weights were updated
+        assert not all(
+            [
+                torch.equal(start_model_state_dict[key], step_1_model_state_dict[key])
+                for key in start_model_state_dict.keys()
+            ]
+        )
+
+    def test_vae_training_pipeline(self, vae, train_dataset, training_configs):
+
+        dir_path = training_configs.output_dir
+
+        # build pipeline
+        pipeline = TrainingPipeline(model=vae, training_config=training_configs)
+
+        assert pipeline.training_config.__dict__ == training_configs.__dict__
+
+        # Launch Pipeline
+        pipeline(
+            train_data=train_dataset.data,  # gives tensor to pipeline
+            eval_data=train_dataset.data,  # gives tensor to pipeline
+        )
+
+        model = deepcopy(pipeline.trainer._best_model)
+
+        training_dir = os.path.join(
+            dir_path, f"VAE_training_{pipeline.trainer._training_signature}"
+        )
+        assert os.path.isdir(training_dir)
+
+        final_dir = os.path.join(training_dir, f"final_model")
+        assert os.path.isdir(final_dir)
+
+        files_list = os.listdir(final_dir)
+
+        assert set(["model.pt", "model_config.json", "training_config.json"]).issubset(
+            set(files_list)
+        )
+
+        # check pickled custom decoder
+        if not vae.model_config.uses_default_decoder:
+            assert "decoder.pkl" in files_list
+
+        else:
+            assert not "decoder.pkl" in files_list
+
+        # check pickled custom encoder
+        if not vae.model_config.uses_default_encoder:
+            assert "encoder.pkl" in files_list
+
+        else:
+            assert not "encoder.pkl" in files_list
+
+        # check reload full model
+        model_rec = AutoModel.load_from_folder(os.path.join(final_dir))
+
+        assert all(
+            [
+                torch.equal(
+                    model_rec.state_dict()[key].cpu(), model.state_dict()[key].cpu()
+                )
+                for key in model.state_dict().keys()
+            ]
+        )
+
+        assert type(model_rec.encoder.cpu()) == type(model.encoder.cpu())
+        assert type(model_rec.decoder.cpu()) == type(model.decoder.cpu())


### PR DESCRIPTION
Added auto mixed precision to BaseTrainer class for train_step, eval_step and predict. Requires passing 'amp=True' to base config. Have tested briefly and seems to run with no issues for training.