### PR TITLE
Add start_epoch variable to base trainer train()

### DIFF
--- a/src/pythae/trainers/base_trainer/base_trainer.py
+++ b/src/pythae/trainers/base_trainer/base_trainer.py
@@ -391,11 +391,12 @@ class BaseTrainer:
         # set callbacks
         self._setup_callbacks()
 
-    def train(self, log_output_dir: str = None):
+    def train(self, log_output_dir: str = None, start_epoch: int = 1):
         """This function is the main training function
 
         Args:
             log_output_dir (str): The path in which the log will be stored
+            start_epoch (int): The starting epoch for training. Useful to continue at correct epoch if resuming training
         """
 
         self.prepare_training()
@@ -434,7 +435,7 @@ class BaseTrainer:
         best_train_loss = 1e10
         best_eval_loss = 1e10
 
-        for epoch in range(1, self.training_config.num_epochs + 1):
+        for epoch in range(start_epoch, self.training_config.num_epochs + start_epoch):
 
             self.callback_handler.on_epoch_begin(
                 training_config=self.training_config,


### PR DESCRIPTION
As far as I can tell, there is no way to resume training currently without the trainer beginning from epoch 1. This should avoid overwrites and allow to continue correctly in schedulers (not tested)