### PR TITLE
predict overridden in rhvae

### DIFF
--- a/src/pythae/models/rhvae/rhvae_model.py
+++ b/src/pythae/models/rhvae/rhvae_model.py
@@ -263,6 +263,57 @@ class RHVAE(VAE):
 
         return output
 
+    def predict(self, inputs: torch.Tensor) -> ModelOutput:
+        """The input data is encoded and decoded without computing loss
+
+        Args:
+            inputs (torch.Tensor): The input data to be reconstructed, as well as to generate the embedding.
+
+        Returns:
+            ModelOutput: An instance of ModelOutput containing reconstruction, raw embedding (output of encoder), and the final embedding (output of metric)
+        """
+        encoder_output = self.encoder(inputs)
+        mu, log_var = encoder_output.embedding, encoder_output.log_covariance
+
+        std = torch.exp(0.5 * log_var)
+        z0, _ = self._sample_gauss(mu, std)
+
+        z = z0
+
+        G = self.G(z)
+        G_inv = self.G_inv(z)
+        L = torch.linalg.cholesky(G)
+
+        G_log_det = -torch.logdet(G_inv)
+
+        gamma = torch.randn_like(z0, device=inputs.device)
+        rho = gamma / self.beta_zero_sqrt
+
+        # sample \rho from N(0, G)
+        rho = (L @ rho.unsqueeze(-1)).squeeze(-1)
+
+        recon_x = self.decoder(z)["reconstruction"]
+
+        for _ in range(self.n_lf):
+
+            # perform leapfrog steps
+
+            # step 1
+            rho_ = self._leap_step_1(recon_x, inputs, z, rho, G_inv, G_log_det)
+
+            # step 2
+            z = self._leap_step_2(recon_x, inputs, z, rho_, G_inv, G_log_det)
+
+            recon_x = self.decoder(z)["reconstruction"]
+
+        output = ModelOutput(
+            recon_x=recon_x,
+            raw_embedding=encoder_output.embedding,
+            embedding=z if self.n_lf > 0 else encoder_output.embedding,
+        )
+
+        return output
+    
     def _leap_step_1(self, recon_x, x, z, rho, G_inv, G_log_det, steps=3):
         """
         Resolves first equation of generalized leapfrog integrator


### PR DESCRIPTION
As unlike other models where we take the embedding output from the encoder as the final "Z", RHVAE's final Z should be after the leapfrog steps, I'm overriding the predict method present inside the base model inside RHVAE model and returning "embedding" after the leapfrog steps (+ returning the "raw" embedding)